### PR TITLE
change utils to add support for linux and fix support for macOS

### DIFF
--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -2,12 +2,14 @@
 #define UTILITY_HPP
 
 #include<vector>
-
-
-class Utils {
-    public:
-        static std::vector<int> getWindowSize();
-};
-
-
+#if defined(__UNIX__) || defined(__linux__) || defined(__APPLE__)
+#include <sys/ioctl.h>
+#include <unistd.h>
+#endif
+#if defined(_WIN32)
+#include<Windows.h>
+#endif
+namespace Utils {
+    std::vector<int> getWindowSize();
+}
 #endif

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -1,11 +1,11 @@
 #include "../include/utility.hpp"
 
-#if defined(__UNIX__) || defined(__APPLE__)
+#if defined(__UNIX__) || defined(__linux__) || defined(__APPLE__)
 
 #include <sys/ioctl.h>
 #include <unistd.h>
 
-TerminalSize TerminalUtils::getTerminalSize() {
+std::vector<int> Utils::getWindowSize() {
     struct winsize w;
     std::vector dim(2,0);
     if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) == -1) {
@@ -35,5 +35,3 @@ std::vector<int> Utils::getWindowSize() {
 }
 
 #endif
-
-//TODO: Linux


### PR DESCRIPTION
PROBLEM:
code doesn't compile on either linux or macOS due to windows dependant function Utils::getwindowSize used in main.cpp

FIX:
Changed utility.cpp and utililty.hpp to only use namespace Utils instead of a separate namespace for different platforms. this code also works on linux so that part was also added to the #if defined statement.